### PR TITLE
fix probable typo in new string length calculation

### DIFF
--- a/src/utils.v
+++ b/src/utils.v
@@ -4,7 +4,7 @@ import strings
 
 fn substr_with_runes(str string, start int, end int) string {
 	r := str.runes()
-	mut sb := strings.new_builder(start - end)
+	mut sb := strings.new_builder(end - start)
 	for i in start .. end {
 		if i >= r.len {
 			break


### PR DESCRIPTION
If the columns content go past the right side of the screen it should be possible to scroll. This typo prevented this, the command exited with error 1 and no error message.